### PR TITLE
drivers:media:tdmb: fix function prototype warning

### DIFF
--- a/drivers/media/tdmb/fc8080/dmbdrv_wrap_fc8080.c
+++ b/drivers/media/tdmb/fc8080/dmbdrv_wrap_fc8080.c
@@ -383,7 +383,7 @@ int dmb_drv_get_dat_sub_ch_cnt(void)
 }
 
 
-char *dmb_drv_get_ensemble_label()
+char *dmb_drv_get_ensemble_label(void)
 {
 	struct esbinfo_t *esb;
 


### PR DESCRIPTION
/kernel/samsung/exynos9820/drivers/media/tdmb/fc8080/dmbdrv_wrap_fc8080.c:386:33: error: a function declaration without a prototype is deprecated in all versions of C [-Werror,-Wstrict-prototypes]  char *dmb_drv_get_ensemble_label()